### PR TITLE
refactor: use CSS variable for provider-item hover and active background color

### DIFF
--- a/core/frontend/src/views/settings/ai-model/components/ModelManager.vue
+++ b/core/frontend/src/views/settings/ai-model/components/ModelManager.vue
@@ -184,11 +184,11 @@ function handleAddModel() {
 				}
 
 				&:hover {
-					background: #eef9ee;
+					background: var(--color-primary-2);
 				}
 
 				&.active {
-					background: #eef9ee;
+					background: var(--color-primary-2);
 				}
 
 				.item-icon {


### PR DESCRIPTION
Replaced hardcoded background color (#eef9ee) for .provider-item hover and active states with CSS variable --color-primary-2 for better theme consistency.

I’ve included a short video showing the issue before and after the change.
[before.webm](https://github.com/user-attachments/assets/9120ee55-abd7-4f92-941f-f4d64cc8d350)
[after.webm](https://github.com/user-attachments/assets/4b6d2fae-d8c0-46db-b160-730ca0422c54)
